### PR TITLE
chore: define lib directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,14 @@
   "description": "Http request signing and verifying",
   "private": false,
   "main": "lib/index.js",
+  "typings": "lib/index.d.ts",
+  "directories": {
+    "lib": "lib",
+    "test": "__tests__"
+  },
+  "files": [
+    "lib"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mattrglobal/http-signatures.git"


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
-->

## Description

Publish is currently publishing the entire source.
Define file directories and typings directories.
<!--- Describe your changes in detail -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/contributing.md)** document.

## Motivation and Context

Missing definitions in `package.json`. Publish is currently publishing the entire src which isn't desirable.
<!--- Why is this change required? What problem does it solve? -->

<!--- If it relates to an open issue, please link to the issue here.
e.g.
[IDA-135](https://mattrglobal.atlassian.net/browse/IDA-135)
-->

[](https://mattrglobal.atlassian.net/browse/)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
