### PR TITLE
feat: add codeql analysis

### DIFF
--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -1,0 +1,56 @@
+name: codeql-analysis
+
+on:
+  push:
+    branches: [master, v3]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [master, v3]
+  schedule:
+    - cron: "0 17 * * 0" # run early each Monday morning (NZT)
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["javascript"]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          # We must fetch at least the immediate parents so that if this is
+          # a pull request then we can checkout the head.
+          fetch-depth: 2
+
+      # If this run was triggered by a pull request event, then checkout
+      # the head of the pull request instead of the merge commit.
+      - run: git checkout HEAD^2
+        if: ${{ github.event_name == 'pull_request' }}
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: ${{ matrix.language }}
+
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v1
+
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
+
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+      #    and modify them (or add more) to build your code if your project
+      #    uses a compiled language
+
+      #- run: |
+      #   make bootstrap
+      #   make release
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
## Description

I've split out the changes for codeql from https://github.com/mattrglobal/http-signatures/pull/32, as we're not sure if they'll go ahead. Will leave this PR open for tracking until we're sure what should be done

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] Changes follow the **[contributing](../docs/contributing.md)** document.

## Motivation and Context

[IDA-4815](https://mattrglobal.atlassian.net/browse/IDA-4815)

[](https://mattrglobal.atlassian.net/browse/)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
