### PR TITLE
fix(deps): move structured-headers to direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "jest": "28.1.1",
     "prettier": "2.7.1",
     "pretty-quick": "2.0.1",
-    "structured-headers": "0.5.0",
     "ts-jest": "28.0.5",
     "ts-node": "8.4.1",
     "typedoc": "0.22.17",
@@ -73,6 +72,7 @@
     "buffer": "6.0.3",
     "neverthrow": "3.0.0",
     "ramda": "0.27.1",
-    "url": "0.11.0"
+    "url": "0.11.0",
+    "structured-headers": "0.5.0"
   }
 }


### PR DESCRIPTION
## Description

Structured-headers is used as part of signing signature header, and therefore should be a direct dependency rather than a dev dependency.

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Motivation and Context

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Which merge strategy will you use?

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)
