### PR TITLE
fix: correct import paths, verifyRequest accepts verifyExpiry argument

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,9 @@
   ],
   "ignorePatterns": ["node_modules", "lib"],
   "rules": {
+    "no-restricted-imports": ["error", {
+        "patterns": ["src/*", "*/lib/*"]
+    }],
     "@typescript-eslint/explicit-function-return-type": "error",
     "@typescript-eslint/no-explicit-any": "error",
     "header/header": [

--- a/src/common/cryptoPrimatives.ts
+++ b/src/common/cryptoPrimatives.ts
@@ -4,7 +4,8 @@
  * Confidential and proprietary
  */
 import crypto, { JsonWebKey } from "crypto";
-import { AlgorithmTypes } from "src/sign";
+
+import { AlgorithmTypes } from "../sign";
 
 export const signEcdsaSha256 =
   (key: JsonWebKey) =>

--- a/src/verify/verifyRequest.ts
+++ b/src/verify/verifyRequest.ts
@@ -6,8 +6,8 @@
 
 import http from "http";
 import { ResultAsync } from "neverthrow";
-import { VerifyResult } from "src/common";
 
+import { VerifyResult } from "../common";
 import { VerifySignatureHeaderError } from "../errors";
 
 import { Verifier } from "./verifySignatureHeader";
@@ -18,9 +18,10 @@ export type VerifyRequestOptions = {
   request: http.IncomingMessage;
   signatureKey?: string;
   body?: Record<string, unknown> | string;
+  verifyExpiry?: boolean;
 };
 export const verifyRequest = (options: VerifyRequestOptions): ResultAsync<VerifyResult, VerifySignatureHeaderError> => {
-  const { request, verifier, body, signatureKey } = options;
+  const { request, verifier, body, signatureKey, verifyExpiry = true } = options;
 
   return verifySignatureHeader({
     url: `https://${request.headers.host}${request.url}`,
@@ -29,5 +30,6 @@ export const verifyRequest = (options: VerifyRequestOptions): ResultAsync<Verify
     signatureKey: signatureKey,
     verifier,
     ...(body && { body }),
+    verifyExpiry,
   });
 };

--- a/src/verify/verifySignatureHeader.ts
+++ b/src/verify/verifySignatureHeader.ts
@@ -7,7 +7,6 @@
 import { JsonWebKey } from "crypto";
 import { errAsync, okAsync, ResultAsync } from "neverthrow";
 import { includes, pickBy, toLower } from "ramda";
-import { AlgorithmTypes } from "src/sign";
 import { parseDictionary, serializeList, serializeDictionary, InnerList } from "structured-headers";
 
 import {
@@ -24,6 +23,7 @@ import {
 } from "../common";
 import { algMap } from "../common/cryptoPrimatives";
 import { VerifySignatureHeaderError } from "../errors";
+import { AlgorithmTypes } from "../sign";
 
 import { verifyDigest } from "./verifyDigest";
 


### PR DESCRIPTION
## Description

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Motivation and Context

Currently, if this library is imported without setting "skipLibCheck": true in tsconfig, it will cause an error due to incorrect import paths.

For the verifyRequest change - this argument is already available if you call verifySignatureHeader directly, but was omitted from verifyRequest. This change is to align them.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Which merge strategy will you use?

<!-- This indicates to reviewers whether they need to check your commits are ready to be rebased on master or not. -->

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)
